### PR TITLE
Fix changelog versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.1.0] - 2022-08-05
+## [2.1.0] - 2022-08-12
 
 ### Changed
 - Upgrade to Node 16
+
+## [2.0.0] - 2020-11-03
+
+### Changed
+- Upgrade to Node 14
 
 ## [1.0.1] - 2020-08-04
 


### PR DESCRIPTION
A tag for version `2.0.0` was pushed when there was an upgrade to Node 14.
Change to add this to the changelog and fix version for upgrade to Node 16.