### PR TITLE
update docker and compose plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.0] - 2023-09-04
+### Changed
+- Upgrade to docker version 24.0.5
+- Upgrade to docker compose version 2.20.2
+
 ## [2.3.0] - 2023-08-03
 ### Changed
 - Upgrade to docker-compose version 1.29.0
+
 ## [2.2.0] - 2023-07-17
 ### Changed
 - Upgrade to Node 18
-## [2.1.0] - 2022-08-12
 
+## [2.1.0] - 2022-08-12
 ### Changed
 - Upgrade to Node 16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,19 @@
-FROM node:18 as docker-compose
-ENV VERSION=1.29.0
-RUN curl -L -o /usr/local/bin/docker-compose \
-    "https://github.com/docker/compose/releases/download/$VERSION/docker-compose-Linux-x86_64"
-COPY docker-compose.sha256 /usr/local/bin/docker-compose.sha256
-RUN sha256sum -c /usr/local/bin/docker-compose.sha256
-RUN chmod +x /usr/local/bin/docker-compose
-
-# https://docs.docker.com/install/linux/docker-ce/debian/
-FROM node:18 as docker
-RUN apt-get update && apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    lsb-release \
-    software-properties-common
-RUN mkdir -p /etc/apt/keyrings
+# https://docs.docker.com/engine/install/debian/
+FROM node:18-bookworm as docker
+ENV VERSION_STRING=5:24.0.5-1~debian.12~bookworm
+RUN apt-get update && apt-get install -y ca-certificates curl gnupg
+RUN install -m 0755 -d /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
-# RUN apt update -y
-# COPY docker-public-key.asc /
-# RUN apt-key add /docker-public-key.asc
-# RUN add-apt-repository \
-#    "deb [arch=amd64] https://download.docker.com/linux/debian \
-#    $(lsb_release -cs) \
-#    stable"
-RUN apt-get update && apt-get install -y docker-ce-cli
+RUN chmod a+r /etc/apt/keyrings/docker.gpg
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update
+RUN apt-get install -y docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
 
-FROM node:18
+FROM node:18-bookworm
 COPY --from=docker /usr/bin/docker /usr/bin/docker
-COPY --from=docker-compose /usr/local/bin/docker-compose /usr/local/bin/docker-compose
+COPY --from=docker /usr/libexec/docker/cli-plugins/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 
 RUN docker -v
-RUN docker-compose -v


### PR DESCRIPTION
Our `ci-node` image used for running tests is using an outdated version of docker that is not in line with what developers are using locally. This is causing discrepancies between local results and pipeline results.
This PR brings the docker version used by the `ci-node` image up to 24.0.5 and uses the compatible docker compose plugin installed alongside docker at version 2.20.2.

Note: The `docker-compose` command is no longer supported. Instead, use `docker compose` after updating to `ci-node:2.4.0`

How to test:
- Pull the `ci-node:2.4.0` image and see that the correct docker versions are used.